### PR TITLE
New Error method as an alternative to Fail with exception

### DIFF
--- a/JSendResponse.cs
+++ b/JSendResponse.cs
@@ -1,0 +1,8 @@
+namespace Mhlabs.WebApi.JsendActionFilter
+{
+    public class JSendResponse
+    {
+        public string Status { get; set; }
+        public object Data { get; set; }
+    }
+}

--- a/Jsend.cs
+++ b/Jsend.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace Mhlabs.WebApi.JsendActionFilter
 {
@@ -19,5 +20,31 @@ namespace Mhlabs.WebApi.JsendActionFilter
         {
             Fail(controller, new FailReason(code, message));
         }
+
+        public static OkObjectResult Error(this Controller controller, FailReason data)
+        {
+            JSendResponse response;
+
+            if (controller.ControllerContext.HasJSendHeader())
+            {
+                response = new JSendResponse { Status = "fail", Data = data };
+            }
+            else
+            {
+                var error = new Exception("Request Failed");
+                error.Data.Add("FailData", data);
+                response = new JSendResponse { Status = "fail", Data = error };
+            }
+
+            Console.WriteLine($"[ERROR] JSendResponse: {JsonConvert.SerializeObject(response)} {Environment.NewLine}");
+
+            return new OkObjectResult(response);
+        }
+
+        public static OkObjectResult Error(this Controller controller, string code = null, string message = null)
+        {
+            return Error(controller, new FailReason(code, message));
+        }
+
     }
 }

--- a/Mhlabs.WebApi.JsendActionFilter.csproj
+++ b/Mhlabs.WebApi.JsendActionFilter.csproj
@@ -6,9 +6,9 @@
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
-    <Version>1.0.5</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.8" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Mhlabs.WebApi.JsendActionFilter
-Action filter for optionally wrapping a response in JSend format. See https://labs.omniti.com/labs/jsend.
+
+Action filter for optionally wrapping a response in JSend format.
+
+See [https://labs.omniti.com/labs/jsend](https://labs.omniti.com/labs/jsend).
+
+_To enable, add the filter as middleware._
 
 ```csharp
 services.AddMvc(s =>
@@ -8,9 +13,20 @@ services.AddMvc(s =>
 });
 ```
 
-Example usage:
+_Example usage:_
 
 ```csharp
+[HttpGet]
+public ActionResult<bool> GetIt(string id, CancellationToken cancellationToken)
+{
+    if (string.IsNullOrWhiteSpace(id))
+    {
+        return this.Error("NO_ID", "Didn't get it.");
+    }
+
+    return true;
+}
+
 [HttpGet]
 public async Task<DtoObject> Get(string id, CancellationToken cancellationToken)
 {
@@ -28,5 +44,4 @@ public async Task<DtoObject> Get(string id, CancellationToken cancellationToken)
 
     return dto;
 }
-
 ```

--- a/ResponseFilterAttribute.cs
+++ b/ResponseFilterAttribute.cs
@@ -24,19 +24,28 @@ namespace Mhlabs.WebApi.JsendActionFilter
 
             if (!context.HasJSendHeader()) return;
 
+            var result = context.Result as OkObjectResult;
+            if (result != null && result.Value as JSendResponse != null)
+            {
+                // error response already set
+                return;
+            }
+
             if (context.Exception != null && context.Exception.GetType() == typeof(JSendFailException))
             {
                 var failExeption = context.Exception as JSendFailException;
 
                 if (context.Result != null) return;
 
-                context.Result = new OkObjectResult(new {status = "fail", data = failExeption?.FailData});
+                context.Result = new OkObjectResult(new { status = "fail", data = failExeption?.FailData });
                 context.ExceptionHandled = true;
             }
             else if (context.Exception == null)
             {
-                ((ObjectResult) context.Result).Value =
-                    new {status = "success", data = ((ObjectResult) context.Result).Value};
+                var objectResult = context.Result as ObjectResult;
+                if(objectResult == null) return;
+                objectResult.Value =
+                    new JSendResponse { Status = "success", Data = objectResult.Value};
             }
         }
     }


### PR DESCRIPTION
Also a bug fix since currently e.g. returning Unauthorized() from a controller method will fail cast to OkObjectResult in filter attribute.

Only downside to the approach with the Error-method is that it forces the use of ObjectResult/ActionResult/IActionResult. That's a good thing though in my opinion since controller methods should always be allowed to return both data and HTTP status codes.

For the actual difference between this approach and the previous, see the code example in README.md. I didn't deprecate the old methods although I had the urge to ;-)